### PR TITLE
feat(auth): add hybrid login with wisc OTP, credentials, and recovery…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,15 @@ DATABASE_URL="postgresql://user:password@hostname/database?sslmode=require&schem
 
 # Authentication
 AUTH_SECRET="generate-with-openssl-rand-base64-32"
+AUTH_PASSWORD_PEPPER="optional-separate-password-pepper"
+AUTH_OTP_SECRET="optional-separate-otp-secret"
 GOOGLE_CLIENT_ID="your-google-client-id"
 GOOGLE_CLIENT_SECRET="your-google-client-secret"
+SMTP_HOST="smtp.example.com"
+SMTP_PORT="587"
+SMTP_USER="smtp-user"
+SMTP_PASS="smtp-password"
+SMTP_FROM="MadSpace <no-reply@madspace.app>"
 
 # Redis (Upstash) — optional, app degrades gracefully without it
 UPSTASH_REDIS_REST_URL="https://your-redis.upstash.io"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.1-dev] - 2026-02-09
+
+### Added
+
+- **Multi-path authentication (implemented)**
+  - Added credentials login via `handle/email + password` using NextAuth Credentials provider
+  - Added `auth` tRPC router with OTP flows:
+    - `requestWiscSignupOtp`
+    - `completeWiscSignup`
+    - `requestRecoveryEmailOtp`
+    - `verifyRecoveryEmailOtp`
+    - `requestPasswordResetOtp`
+    - `resetPasswordWithOtp`
+  - Added account-security APIs:
+    - `getSecurityProfile`
+    - `updateLoginHandle`
+    - `setPassword`
+- **New identity/security models**
+  - Added Prisma models: `UserEmail`, `UserCredential`, `EmailOtpChallenge`
+  - Added user fields: `loginHandle`, `loginHandleNormalized`, `eligibilityStatus`, `firstVerifiedAt`, `lastWiscVerifiedAt`, `requiresRecoverySetup`
+- **Graduate-safe access path**
+  - Added recovery-email binding flow (`non-@wisc.edu`) for long-term account recovery
+  - Added profile-side security panel for handle, recovery email, and password management
+
+### Changed
+
+- **Auth UX pages**
+  - `/auth/signin` now supports Google + password login + OTP reset UI
+  - `/auth/signup` now supports wisc OTP signup + password + handle setup
+- **Authorization checks**
+  - Review creation now checks `eligibilityStatus` instead of raw `@wisc.edu` suffix
+  - Course review gating count now resolves users by `session.user.id` (not email lookup)
+- **Google sign-in reconciliation**
+  - On Google login, user identity is reconciled into `UserEmail` and normalized handle is guaranteed
+
+### Migration
+
+- Applied `20260208195739_add_credentials_auth_and_identity_models`
+  - Backfilled legacy users into `UserEmail`
+  - Backfilled eligibility and verification timestamps for existing @wisc users
+
 ## [0.6.0-dev] - 2026-02-08
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # MadSpace Development Progress
 
-**Last Updated**: 2026-02-08  
+**Last Updated**: 2026-02-09  
 **Current Phase**: Phase 4 + Data Integrity Stabilization  
 **Overall Completion**: ~90%
 
@@ -38,6 +38,19 @@ Overall:                 ██████████████████�
   - Grade scale unified to `A / AB / B / BC / C / D / F`
   - Dynamic color logic aligned with GPA distribution palette
   - Stronger visual feedback for assessments and detailed rating modules
+
+### ✅ Auth Upgrade (Credentials + OTP + Recovery)
+- [x] **Hybrid authentication shipped**:
+  - Google OAuth (@wisc.edu verification path)
+  - Handle/email + password credentials login
+  - Wisc email OTP signup flow
+- [x] **Graduate-safe account continuity**:
+  - Added recovery-email verification flow (`non-@wisc.edu`)
+  - Added password reset OTP flow
+  - Added profile security panel (handle / recovery email / password)
+- [x] **Identity model migration deployed**:
+  - `UserEmail`, `UserCredential`, `EmailOtpChallenge`
+  - `eligibilityStatus`-based review authorization
 
 ### ✅ Browse / Discovery UX
 - [x] **Courses page featured panels** updated:
@@ -91,7 +104,7 @@ Overall:                 ██████████████████�
 
 ## ✅ Phase 2: Core Features — 100% COMPLETE
 
-- [x] User authentication (NextAuth v5 + Google OAuth, @wisc.edu only)
+- [x] User authentication (NextAuth v5 + Google OAuth + credentials login + OTP verification)
 - [x] Course list page with search + filters + pagination
 - [x] Course detail page (grade distributions, prereqs, reviews)
 - [x] Review system (create with 4-dimension ratings: Content/Teaching/Grading/Workload)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Inspired by [USTSpace](https://ust.space) — a beloved student community platfo
 - 👨‍🏫 **Instructor profiles** — Teaching portfolios with radar charts, timelines, and aggregated ratings
 - 🔍 **Smart search** — Full-text search with course code alias support (e.g. `CS 577` → `COMP SCI 577`)
 - 🏆 **Contributor level system** — Quality-weighted XP progression (🐾→🐣→🐥→🦡→👑→🏆)
-- 🔒 **@wisc.edu verified** — Only UW-Madison students can review
+- 🔐 **Hybrid auth** — @wisc.edu OTP verification + Google OAuth + handle/password login
+- 🎓 **Graduate-safe recovery** — bind non-@wisc recovery email to keep access after graduation
 - 🛡️ **Content moderation** — Admin portal with reporting queue
 - 🌙 **Dark mode** — System-aware theme switching
 
@@ -45,7 +46,7 @@ Inspired by [USTSpace](https://ust.space) — a beloved student community platfo
 | Database | PostgreSQL (Neon) + Prisma ORM |
 | Search | PostgreSQL `tsvector` + GIN index |
 | Caching | Upstash Redis (graceful degradation) |
-| Auth | NextAuth.js v5 + Google OAuth |
+| Auth | NextAuth.js v5 + Google OAuth + Credentials + OTP |
 | Data Fetching | TanStack Query (React Query) |
 | Deployment | Vercel |
 
@@ -68,7 +69,8 @@ Data sourced from UW-Madison's course catalog and [MadGrades](https://madgrades.
 
 - Node.js 18+
 - PostgreSQL database (or a [Neon](https://neon.tech/) account)
-- Google OAuth credentials (for @wisc.edu authentication)
+- Google OAuth credentials
+- SMTP credentials (for OTP delivery)
 
 ### Setup
 

--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -11,8 +11,10 @@ export default async function AuthErrorPage({
   
   const errorMessages: Record<string, string> = {
     Configuration: 'There is a problem with the server configuration.',
-    AccessDenied: 'You must use a @wisc.edu email address.',
+    AccessDenied: 'You must verify with a @wisc.edu email first.',
+    AccountLink: 'We could not safely link this login to your existing account.',
     Verification: 'The verification link has expired or was already used.',
+    CredentialsSignin: 'Invalid handle/email or password.',
     Default: 'An error occurred during authentication.',
   }
 
@@ -40,7 +42,7 @@ export default async function AuthErrorPage({
 
           {error === 'AccessDenied' && (
             <p className="text-slate-700 dark:text-slate-300 mb-6">
-              MadSpace is only available to UW-Madison students. Please sign in with your @wisc.edu email address.
+              MadSpace requires UW-Madison verification. Use your @wisc.edu email to verify first, then you can keep logging in with handle/password.
             </p>
           )}
 

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,18 +1,24 @@
 import { Logo } from '@/components/Logo'
 import Link from 'next/link'
-import { AlertCircle } from 'lucide-react'
-import { signIn } from '@/auth'
+import { AuthSignInPanel } from '@/components/auth/AuthSignInPanel'
 
-export default function SignInPage() {
+export default async function SignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string }>
+}) {
+  const params = await searchParams
+  const callbackUrl = params.callbackUrl || '/courses'
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 flex items-center justify-center px-4">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 flex items-center justify-center px-4 py-10">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
           <div className="flex justify-center mb-4">
             <Logo size={48} />
           </div>
           <h1 className="text-3xl font-bold text-slate-900 mb-2">Welcome to MadSpace</h1>
-          <p className="text-slate-700 dark:text-slate-300">Sign in with your @wisc.edu Google account</p>
+          <p className="text-slate-700">Sign in with Google or with your handle + password</p>
           <Link
             href="/"
             className="inline-block mt-3 text-sm text-slate-600 hover:text-slate-900 underline underline-offset-4"
@@ -21,42 +27,11 @@ export default function SignInPage() {
           </Link>
         </div>
 
-        <div className="bg-white rounded-xl shadow-lg p-8 border border-slate-200">
-          <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg flex gap-3">
-            <AlertCircle className="text-blue-600 flex-shrink-0 mt-0.5" size={20} />
-            <div className="text-sm text-blue-800">
-              <strong>UW Madison students only.</strong> You must use a @wisc.edu email address to access MadSpace.
-            </div>
-          </div>
+        <AuthSignInPanel callbackUrl={callbackUrl} />
 
-          <form
-            action={async () => {
-              'use server'
-              await signIn('google', { redirectTo: '/courses' })
-            }}
-          >
-            <button
-              type="submit"
-              className="w-full bg-white text-slate-800 border border-slate-300 py-3 rounded-lg font-medium hover:bg-slate-50 transition-colors flex items-center justify-center gap-2"
-            >
-              <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
-                <path fill="#EA4335" d="M12 10.2v3.9h5.5c-.24 1.3-.99 2.4-2.1 3.13l3.2 2.48c1.86-1.71 2.94-4.22 2.94-7.21 0-.66-.06-1.3-.17-1.9H12z" />
-                <path fill="#34A853" d="M12 22c2.7 0 4.96-.9 6.61-2.44l-3.2-2.48c-.89.59-2.03.95-3.41.95-2.62 0-4.85-1.77-5.65-4.15l-3.31 2.56A9.98 9.98 0 0 0 12 22z" />
-                <path fill="#FBBC05" d="M6.35 13.88A5.97 5.97 0 0 1 6 12c0-.65.12-1.28.35-1.88L3.04 7.56A9.98 9.98 0 0 0 2 12c0 1.62.39 3.14 1.04 4.44l3.31-2.56z" />
-                <path fill="#4285F4" d="M12 5.97c1.47 0 2.79.5 3.83 1.49l2.87-2.87C16.95 2.96 14.7 2 12 2c-3.9 0-7.25 2.23-8.96 5.56l3.31 2.56c.8-2.38 3.03-4.15 5.65-4.15z" />
-              </svg>
-              Continue with Google
-            </button>
-          </form>
-
-          <p className="mt-6 text-center text-sm text-slate-700 dark:text-slate-300">
-            New to MadSpace? Just sign in with your UW Madison Google account to get started.
-          </p>
-        </div>
-
-        <div className="mt-6 text-center text-xs text-slate-600 dark:text-slate-400">
+        <div className="mt-6 text-center text-xs text-slate-600">
           <p>
-            By continuing, you agree to MadSpace's{' '}
+            By continuing, you agree to MadSpace&apos;s{' '}
             <Link href="/terms" className="underline hover:text-slate-700">
               Terms of Service
             </Link>{' '}

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,18 +1,17 @@
 import Link from 'next/link'
 import { Logo } from '@/components/Logo'
-import { AlertCircle } from 'lucide-react'
-import { signIn } from '@/auth'
+import { AuthSignupPanel } from '@/components/auth/AuthSignupPanel'
 
 export default function SignUpPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 flex items-center justify-center px-4">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 flex items-center justify-center px-4 py-10">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
           <div className="flex justify-center mb-4">
             <Logo size={48} />
           </div>
           <h1 className="text-3xl font-bold text-slate-900 mb-2">Join MadSpace</h1>
-          <p className="text-slate-700 dark:text-slate-300">Create your account to start reviewing courses</p>
+          <p className="text-slate-700">Verify with @wisc.edu, then keep using handle + password</p>
           <Link
             href="/"
             className="inline-block mt-3 text-sm text-slate-600 hover:text-slate-900 underline underline-offset-4"
@@ -21,51 +20,7 @@ export default function SignUpPage() {
           </Link>
         </div>
 
-        <div className="bg-white rounded-xl shadow-lg p-8 border border-slate-200">
-          <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg flex gap-3">
-            <AlertCircle className="text-blue-600 flex-shrink-0 mt-0.5" size={20} />
-            <div className="text-sm text-blue-800">
-              <strong>UW Madison students only.</strong> You must use a @wisc.edu email address.
-            </div>
-          </div>
-
-          <form
-            action={async () => {
-              'use server'
-              await signIn('google', { redirectTo: '/courses' })
-            }}
-          >
-            <button
-              type="submit"
-              className="w-full bg-white text-slate-800 border border-slate-300 py-3 rounded-lg font-medium hover:bg-slate-50 transition-colors flex items-center justify-center gap-2"
-            >
-              <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
-                <path fill="#EA4335" d="M12 10.2v3.9h5.5c-.24 1.3-.99 2.4-2.1 3.13l3.2 2.48c1.86-1.71 2.94-4.22 2.94-7.21 0-.66-.06-1.3-.17-1.9H12z" />
-                <path fill="#34A853" d="M12 22c2.7 0 4.96-.9 6.61-2.44l-3.2-2.48c-.89.59-2.03.95-3.41.95-2.62 0-4.85-1.77-5.65-4.15l-3.31 2.56A9.98 9.98 0 0 0 12 22z" />
-                <path fill="#FBBC05" d="M6.35 13.88A5.97 5.97 0 0 1 6 12c0-.65.12-1.28.35-1.88L3.04 7.56A9.98 9.98 0 0 0 2 12c0 1.62.39 3.14 1.04 4.44l3.31-2.56z" />
-                <path fill="#4285F4" d="M12 5.97c1.47 0 2.79.5 3.83 1.49l2.87-2.87C16.95 2.96 14.7 2 12 2c-3.9 0-7.25 2.23-8.96 5.56l3.31 2.56c.8-2.38 3.03-4.15 5.65-4.15z" />
-              </svg>
-              Continue with Google
-            </button>
-          </form>
-
-          <p className="mt-3 text-center text-xs text-slate-600 dark:text-slate-400">
-            Use your @wisc.edu email to create an account
-          </p>
-
-          <p className="mt-6 text-center text-sm text-slate-700 dark:text-slate-300">
-            Already have an account?{' '}
-            <Link href="/auth/signin" className="text-uw-red hover:text-uw-dark font-medium">
-              Sign in
-            </Link>
-          </p>
-        </div>
-
-        <div className="mt-6 p-4 bg-white/50 rounded-lg border border-slate-200">
-          <p className="text-xs text-slate-700 dark:text-slate-300 text-center">
-            <strong>Community Guidelines:</strong> Be respectful, honest, and constructive in your reviews. False or misleading information will result in account suspension.
-          </p>
-        </div>
+        <AuthSignupPanel />
       </div>
     </div>
   )

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -15,7 +15,7 @@ export default function PrivacyPage() {
 
         <h1 className="text-3xl font-bold text-text-primary mt-6 mb-4">Privacy Policy</h1>
         <div className="bg-surface-primary border border-surface-tertiary rounded-xl p-6 space-y-4 text-sm text-text-secondary leading-6">
-          <p>MadSpace uses UW Google sign-in to verify student identity and access.</p>
+          <p>MadSpace uses UW verification (Google or email OTP) and optional handle/password login to protect account access.</p>
           <p>We store account basics, reviews, votes, and comments needed to operate the platform.</p>
           <p>We do not sell personal data. Data is used only for product functionality and moderation.</p>
           <p>If you need account/content removal, contact the project maintainer.</p>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -8,6 +8,7 @@ import { signOut } from '@/auth'
 import { computeContributorLevel, getAllLevels } from '@/lib/contributorLevel'
 import { toOfficialCode } from '@/lib/courseCodeDisplay'
 import { NicknameEditor } from '@/components/NicknameEditor'
+import { ProfileSecuritySettings } from '@/components/auth/ProfileSecuritySettings'
 
 export default async function ProfilePage() {
   const session = await auth()
@@ -240,6 +241,8 @@ export default async function ProfilePage() {
 
           {/* Sidebar: Saved Courses + Level Info */}
           <div className="space-y-6">
+            <ProfileSecuritySettings />
+
             {/* Contributor Level Card */}
             <div className="bg-surface-primary rounded-xl border border-surface-tertiary p-6">
               <h2 className="text-lg font-bold text-text-primary mb-4 flex items-center gap-2">

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,8 +1,17 @@
 import type { NextAuthConfig } from 'next-auth'
 import Google from 'next-auth/providers/google'
-import Email from 'next-auth/providers/email'
+import Credentials from 'next-auth/providers/credentials'
 import { PrismaAdapter } from '@auth/prisma-adapter'
 import { prisma } from '@/lib/prisma'
+import {
+  isValidHandle,
+  normalizeEmail,
+  normalizeHandle,
+  resolveUniqueHandle,
+  suggestHandleFromEmail,
+  isWiscEmail,
+} from '@/lib/authIdentity'
+import { verifyPassword } from '@/lib/password'
 
 // Validate environment variables
 if (!process.env.GOOGLE_CLIENT_ID) {
@@ -15,10 +24,13 @@ if (!process.env.AUTH_SECRET) {
   throw new Error('Missing AUTH_SECRET environment variable')
 }
 
+const ALLOWED_ELIGIBILITY = ['STUDENT_VERIFIED', 'ALUMNI_VERIFIED'] as const
+const PASSWORD_MAX_FAILED_ATTEMPTS = 5
+const PASSWORD_LOCK_MINUTES = 15
+
 export const authConfig: NextAuthConfig = {
   adapter: PrismaAdapter(prisma),
   providers: [
-    // Google OAuth
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
@@ -27,30 +39,184 @@ export const authConfig: NextAuthConfig = {
           prompt: 'consent',
           access_type: 'offline',
           response_type: 'code',
-          hd: 'wisc.edu' // Restrict to @wisc.edu domain
+          hd: 'wisc.edu',
+        },
+      },
+      allowDangerousEmailAccountLinking: true,
+    }),
+    Credentials({
+      name: 'Handle / Email + Password',
+      credentials: {
+        identifier: { label: 'Handle or email', type: 'text' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        const identifier = String(credentials?.identifier ?? '').trim()
+        const password = String(credentials?.password ?? '')
+        if (!identifier || !password) return null
+
+        const isEmailIdentifier = identifier.includes('@')
+        const user = isEmailIdentifier
+          ? (
+              await prisma.userEmail.findUnique({
+              where: { emailNormalized: normalizeEmail(identifier) },
+              include: { user: { include: { credential: true } } },
+            })
+            )?.user
+          : await prisma.user.findUnique({
+              where: { loginHandleNormalized: normalizeHandle(identifier) },
+              include: { credential: true },
+            })
+
+        if (!user || !user.credential) return null
+        if (!ALLOWED_ELIGIBILITY.includes(user.eligibilityStatus as (typeof ALLOWED_ELIGIBILITY)[number])) {
+          return null
+        }
+
+        const now = new Date()
+        if (user.credential.lockedUntil && user.credential.lockedUntil > now) {
+          return null
+        }
+
+        const verified = await verifyPassword(password, user.credential.passwordHash)
+        if (!verified) {
+          const nextFailed = user.credential.failedAttempts + 1
+          await prisma.userCredential.update({
+            where: { userId: user.id },
+            data: {
+              failedAttempts: nextFailed,
+              lockedUntil:
+                nextFailed >= PASSWORD_MAX_FAILED_ATTEMPTS
+                  ? new Date(Date.now() + PASSWORD_LOCK_MINUTES * 60 * 1000)
+                  : null,
+            },
+          })
+          return null
+        }
+
+        await prisma.userCredential.update({
+          where: { userId: user.id },
+          data: {
+            failedAttempts: 0,
+            lockedUntil: null,
+          },
+        })
+
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name ?? null,
+          image: user.image ?? null,
         }
       },
-      allowDangerousEmailAccountLinking: true
-    })
+    }),
   ],
   callbacks: {
-    async signIn({ user, account, profile }) {
-      // Strictly enforce @wisc.edu emails only
-      if (user.email && !user.email.endsWith('@wisc.edu')) {
-        console.error('Sign in rejected: non-wisc.edu email', user.email)
+    async signIn({ user, account }) {
+      if (account?.provider !== 'google') return true
+
+      const normalizedEmail = normalizeEmail(user.email || '')
+      if (!normalizedEmail || !isWiscEmail(normalizedEmail)) {
         return '/auth/error?error=AccessDenied'
       }
+
+      try {
+        await prisma.$transaction(async (tx) => {
+          const existingIdentity = await tx.userEmail.findUnique({
+            where: { emailNormalized: normalizedEmail },
+            select: { userId: true },
+          })
+
+          const userId = existingIdentity?.userId || user.id
+          if (!userId) {
+            throw new Error('MISSING_USER')
+          }
+
+          if (existingIdentity && user.id && existingIdentity.userId !== user.id) {
+            throw new Error('ACCOUNT_LINK_CONFLICT')
+          }
+
+          const existingUser = await tx.user.findUnique({
+            where: { id: userId },
+            select: {
+              id: true,
+              loginHandle: true,
+              firstVerifiedAt: true,
+            },
+          })
+
+          if (!existingUser) {
+            throw new Error('MISSING_USER')
+          }
+
+          const hasRecovery = await tx.userEmail.count({
+            where: {
+              userId,
+              type: 'RECOVERY',
+              isVerified: true,
+              canLogin: true,
+            },
+          })
+
+          const desiredHandle = existingUser.loginHandle || suggestHandleFromEmail(normalizedEmail)
+          const finalHandle =
+            existingUser.loginHandle && isValidHandle(existingUser.loginHandle)
+              ? normalizeHandle(existingUser.loginHandle)
+              : await resolveUniqueHandle(tx, desiredHandle)
+
+          await tx.user.update({
+            where: { id: userId },
+            data: {
+              email: normalizedEmail,
+              emailVerified: new Date(),
+              eligibilityStatus: 'STUDENT_VERIFIED',
+              firstVerifiedAt: existingUser.firstVerifiedAt || new Date(),
+              lastWiscVerifiedAt: new Date(),
+              loginHandle: finalHandle,
+              loginHandleNormalized: finalHandle,
+              requiresRecoverySetup: hasRecovery === 0,
+            },
+          })
+
+          await tx.userEmail.upsert({
+            where: { emailNormalized: normalizedEmail },
+            update: {
+              userId,
+              email: normalizedEmail,
+              type: 'UNIVERSITY',
+              isVerified: true,
+              canLogin: true,
+              verifiedAt: new Date(),
+            },
+            create: {
+              userId,
+              email: normalizedEmail,
+              emailNormalized: normalizedEmail,
+              type: 'UNIVERSITY',
+              isVerified: true,
+              canLogin: true,
+              verifiedAt: new Date(),
+            },
+          })
+        })
+      } catch (error) {
+        console.error('[auth.signIn.google] failed to reconcile identity', error)
+        return '/auth/error?error=AccountLink'
+      }
+
       return true
     },
     async session({ session, user }) {
       if (session.user) {
         session.user.id = user.id
-        // Expose nickname and role in session
         ;(session.user as any).nickname = (user as any).nickname || null
         ;(session.user as any).role = (user as any).role || 'STUDENT'
+        ;(session.user as any).loginHandle = (user as any).loginHandle || null
+        ;(session.user as any).eligibilityStatus = (user as any).eligibilityStatus || 'UNVERIFIED'
+        ;(session.user as any).requiresRecoverySetup = (user as any).requiresRecoverySetup || false
       }
       return session
-    }
+    },
   },
   pages: {
     signIn: '/auth/signin',
@@ -58,8 +224,8 @@ export const authConfig: NextAuthConfig = {
   },
   session: {
     strategy: 'database',
-    maxAge: 30 * 24 * 60 * 60, // 30 days
-    updateAge: 24 * 60 * 60, // 24 hours
+    maxAge: 30 * 24 * 60 * 60,
+    updateAge: 24 * 60 * 60,
   },
   debug: process.env.NODE_ENV === 'development',
 }

--- a/components/ContributorProgress.tsx
+++ b/components/ContributorProgress.tsx
@@ -46,7 +46,7 @@ export function ContributorProgress() {
           href="/auth/signin"
           className="block w-full py-2 text-center text-sm font-medium bg-wf-crimson text-white rounded-lg hover:bg-wf-crimson-dark transition-colors"
         >
-          Sign In with @wisc.edu
+          Sign In to Continue
         </Link>
       </div>
     )

--- a/components/CoursePageLayout.tsx
+++ b/components/CoursePageLayout.tsx
@@ -1332,13 +1332,13 @@ export function CoursePageLayout({
                 </div>
                 <h3 className="text-lg font-semibold text-text-primary mb-2">Sign in to see student reviews</h3>
                 <p className="text-sm text-text-secondary max-w-md mx-auto mb-6">
-                  Reviews are only visible to verified UW-Madison students (@wisc.edu). Your reviews and identity are protected.
+                  Reviews are only visible to verified UW-Madison community accounts. First-time verification requires @wisc.edu.
                 </p>
                 <Link
                   href="/auth/signin"
                   className="inline-flex items-center gap-2 px-6 py-3 bg-wf-crimson text-white rounded-lg hover:bg-wf-crimson-dark transition-colors font-medium"
                 >
-                  Sign in with Google
+                  Sign in to continue
                 </Link>
               </div>
             )}

--- a/components/ReviewGate.tsx
+++ b/components/ReviewGate.tsx
@@ -36,7 +36,7 @@ export function ReviewGateOverlay({ totalReviews, userReviewCount, isLoggedIn, c
         <p className="text-sm text-text-secondary max-w-md mx-auto mb-6">
           {isLoggedIn
             ? 'Share your experience with any course to unlock all reviews across the entire platform.'
-            : 'Sign in with your @wisc.edu email and write one review to unlock full access.'}
+            : 'Sign in and write one review to unlock full access. First-time verification requires @wisc.edu.'}
         </p>
 
         {isLoggedIn ? (

--- a/components/auth/AuthSignInPanel.tsx
+++ b/components/auth/AuthSignInPanel.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useMemo, useState } from 'react'
+import { signIn } from 'next-auth/react'
+import { AlertCircle, KeyRound, Mail, UserCircle } from 'lucide-react'
+import { toast } from 'sonner'
+import { trpc } from '@/lib/trpc/client'
+
+interface AuthSignInPanelProps {
+  callbackUrl?: string
+}
+
+export function AuthSignInPanel({ callbackUrl = '/courses' }: AuthSignInPanelProps) {
+  const router = useRouter()
+
+  const [identifier, setIdentifier] = useState('')
+  const [password, setPassword] = useState('')
+  const [isSigningIn, setIsSigningIn] = useState(false)
+
+  const [showReset, setShowReset] = useState(false)
+  const [resetIdentifier, setResetIdentifier] = useState('')
+  const [resetEmail, setResetEmail] = useState('')
+  const [resetCode, setResetCode] = useState('')
+  const [resetPassword, setResetPassword] = useState('')
+
+  const requestReset = trpc.auth.requestPasswordResetOtp.useMutation({
+    onSuccess: (data) => {
+      toast.success('Verification code sent if your account exists.')
+      if (data.devCode) {
+        toast.info(`Dev OTP: ${data.devCode}`)
+      }
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  const completeReset = trpc.auth.resetPasswordWithOtp.useMutation({
+    onSuccess: () => {
+      toast.success('Password reset successful. You can sign in now.')
+      setResetCode('')
+      setResetPassword('')
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  const canSubmit = useMemo(() => identifier.trim().length >= 3 && password.length >= 8, [identifier, password])
+
+  const onCredentialsSignIn = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!canSubmit) return
+
+    setIsSigningIn(true)
+    try {
+      const result = await signIn('credentials', {
+        identifier: identifier.trim(),
+        password,
+        redirect: false,
+      })
+
+      if (!result || result.error) {
+        toast.error('Sign in failed. Check your handle/email and password.')
+        return
+      }
+
+      router.push(callbackUrl)
+      router.refresh()
+    } finally {
+      setIsSigningIn(false)
+    }
+  }
+
+  const onGoogleSignIn = async () => {
+    await signIn('google', { callbackUrl })
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-lg p-8 border border-slate-200 space-y-6">
+      <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg flex gap-3">
+        <AlertCircle className="text-blue-600 flex-shrink-0 mt-0.5" size={20} />
+        <div className="text-sm text-blue-800">
+          <strong>UW-Madison verification required.</strong> First-time accounts must verify with a <code>@wisc.edu</code> email. After that, you can use your handle + password.
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onGoogleSignIn}
+        className="w-full bg-white text-slate-800 border border-slate-300 py-3 rounded-lg font-medium hover:bg-slate-50 transition-colors flex items-center justify-center gap-2"
+      >
+        <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+          <path fill="#EA4335" d="M12 10.2v3.9h5.5c-.24 1.3-.99 2.4-2.1 3.13l3.2 2.48c1.86-1.71 2.94-4.22 2.94-7.21 0-.66-.06-1.3-.17-1.9H12z" />
+          <path fill="#34A853" d="M12 22c2.7 0 4.96-.9 6.61-2.44l-3.2-2.48c-.89.59-2.03.95-3.41.95-2.62 0-4.85-1.77-5.65-4.15l-3.31 2.56A9.98 9.98 0 0 0 12 22z" />
+          <path fill="#FBBC05" d="M6.35 13.88A5.97 5.97 0 0 1 6 12c0-.65.12-1.28.35-1.88L3.04 7.56A9.98 9.98 0 0 0 2 12c0 1.62.39 3.14 1.04 4.44l3.31-2.56z" />
+          <path fill="#4285F4" d="M12 5.97c1.47 0 2.79.5 3.83 1.49l2.87-2.87C16.95 2.96 14.7 2 12 2c-3.9 0-7.25 2.23-8.96 5.56l3.31 2.56c.8-2.38 3.03-4.15 5.65-4.15z" />
+        </svg>
+        Continue with Google
+      </button>
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <div className="w-full border-t border-slate-200" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-white px-2 text-slate-500">or</span>
+        </div>
+      </div>
+
+      <form onSubmit={onCredentialsSignIn} className="space-y-3">
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700 mb-1.5 block">Handle or login email</span>
+          <div className="relative">
+            <UserCircle size={16} className="absolute left-3 top-3.5 text-slate-400" />
+            <input
+              type="text"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
+              placeholder="abc123 or abc123@wisc.edu"
+              className="w-full border border-slate-300 rounded-lg pl-9 pr-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-uw-red/30 focus:border-uw-red"
+              autoComplete="username"
+              required
+            />
+          </div>
+        </label>
+
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700 mb-1.5 block">Password</span>
+          <div className="relative">
+            <KeyRound size={16} className="absolute left-3 top-3.5 text-slate-400" />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="At least 8 characters"
+              className="w-full border border-slate-300 rounded-lg pl-9 pr-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-uw-red/30 focus:border-uw-red"
+              autoComplete="current-password"
+              minLength={8}
+              required
+            />
+          </div>
+        </label>
+
+        <button
+          type="submit"
+          disabled={isSigningIn || !canSubmit}
+          className="w-full py-2.5 rounded-lg font-medium bg-slate-900 text-white hover:bg-slate-800 disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {isSigningIn ? 'Signing in...' : 'Sign in with password'}
+        </button>
+      </form>
+
+      <div className="flex items-center justify-between text-sm">
+        <button
+          type="button"
+          onClick={() => setShowReset((prev) => !prev)}
+          className="text-slate-600 hover:text-slate-800"
+        >
+          {showReset ? 'Hide password reset' : 'Forgot password?'}
+        </button>
+        <Link href="/auth/signup" className="text-uw-red hover:text-uw-dark font-medium">
+          Create account
+        </Link>
+      </div>
+
+      {showReset && (
+        <div className="border border-slate-200 rounded-lg p-4 bg-slate-50 space-y-3">
+          <p className="text-sm font-medium text-slate-800">Reset password</p>
+
+          <label className="block">
+            <span className="text-xs text-slate-600">Step 1: Request OTP with your handle or email</span>
+            <input
+              type="text"
+              value={resetIdentifier}
+              onChange={(e) => setResetIdentifier(e.target.value)}
+              placeholder="abc123 or abc123@wisc.edu"
+              className="mt-1 w-full border border-slate-300 rounded-lg px-3 py-2"
+            />
+          </label>
+
+          <button
+            type="button"
+            onClick={() => requestReset.mutate({ identifier: resetIdentifier })}
+            disabled={requestReset.isPending || resetIdentifier.trim().length < 3}
+            className="w-full py-2 rounded-lg border border-slate-300 text-slate-700 hover:bg-white disabled:opacity-60"
+          >
+            {requestReset.isPending ? 'Sending code...' : 'Send reset code'}
+          </button>
+
+          <label className="block">
+            <span className="text-xs text-slate-600">Step 2: Enter the email that received the code</span>
+            <div className="relative mt-1">
+              <Mail size={16} className="absolute left-3 top-3 text-slate-400" />
+              <input
+                type="email"
+                value={resetEmail}
+                onChange={(e) => setResetEmail(e.target.value)}
+                placeholder="recovery@gmail.com or you@wisc.edu"
+                className="w-full border border-slate-300 rounded-lg pl-9 pr-3 py-2"
+              />
+            </div>
+          </label>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <input
+              type="text"
+              value={resetCode}
+              onChange={(e) => setResetCode(e.target.value)}
+              placeholder="6-digit code"
+              className="border border-slate-300 rounded-lg px-3 py-2"
+            />
+            <input
+              type="password"
+              value={resetPassword}
+              onChange={(e) => setResetPassword(e.target.value)}
+              placeholder="New password"
+              className="border border-slate-300 rounded-lg px-3 py-2"
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={() =>
+              completeReset.mutate({
+                email: resetEmail,
+                code: resetCode,
+                password: resetPassword,
+              })
+            }
+            disabled={
+              completeReset.isPending ||
+              !resetEmail.includes('@') ||
+              resetCode.trim().length !== 6 ||
+              resetPassword.length < 8
+            }
+            className="w-full py-2 rounded-lg bg-uw-red text-white hover:bg-uw-dark disabled:opacity-60"
+          >
+            {completeReset.isPending ? 'Resetting...' : 'Reset password'}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/auth/AuthSignupPanel.tsx
+++ b/components/auth/AuthSignupPanel.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useMemo, useState } from 'react'
+import { signIn } from 'next-auth/react'
+import { AlertCircle, CheckCircle2, KeyRound, Mail, UserCircle } from 'lucide-react'
+import { toast } from 'sonner'
+import { trpc } from '@/lib/trpc/client'
+
+export function AuthSignupPanel() {
+  const router = useRouter()
+
+  const [email, setEmail] = useState('')
+  const [code, setCode] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [loginHandle, setLoginHandle] = useState('')
+  const [otpSent, setOtpSent] = useState(false)
+
+  const requestOtp = trpc.auth.requestWiscSignupOtp.useMutation({
+    onSuccess: (data) => {
+      setOtpSent(true)
+      toast.success('Verification code sent to your @wisc.edu email.')
+      if (data.devCode) {
+        toast.info(`Dev OTP: ${data.devCode}`)
+      }
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  const completeSignup = trpc.auth.completeWiscSignup.useMutation({
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  const canRequestOtp = useMemo(() => {
+    const normalized = email.trim().toLowerCase()
+    return normalized.endsWith('@wisc.edu')
+  }, [email])
+
+  const canComplete = useMemo(() => {
+    return (
+      otpSent &&
+      email.trim().toLowerCase().endsWith('@wisc.edu') &&
+      code.trim().length === 6 &&
+      password.length >= 8 &&
+      confirmPassword.length >= 8
+    )
+  }, [otpSent, email, code, password, confirmPassword])
+
+  const onGoogleSignup = async () => {
+    await signIn('google', { callbackUrl: '/courses' })
+  }
+
+  const onCompleteSignup = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!canComplete) return
+
+    if (password !== confirmPassword) {
+      toast.error('Passwords do not match.')
+      return
+    }
+
+    const result = await completeSignup.mutateAsync({
+      email,
+      code,
+      password,
+      loginHandle: loginHandle.trim() || undefined,
+    })
+
+    const loginIdentifier = result.loginHandle || email
+    const signInResult = await signIn('credentials', {
+      identifier: loginIdentifier,
+      password,
+      redirect: false,
+    })
+
+    if (!signInResult || signInResult.error) {
+      toast.success('Account created. Please sign in with your new credentials.')
+      router.push('/auth/signin')
+      return
+    }
+
+    toast.success(`Welcome! Your login handle is ${result.loginHandle}.`)
+    router.push('/courses')
+    router.refresh()
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-lg p-8 border border-slate-200 space-y-6">
+      <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg flex gap-3">
+        <AlertCircle className="text-blue-600 flex-shrink-0 mt-0.5" size={20} />
+        <div className="text-sm text-blue-800">
+          <strong>Step 1 verification uses @wisc.edu.</strong> After signup, you can log in with your handle + password, and later bind a recovery email for post-graduation access.
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onGoogleSignup}
+        className="w-full bg-white text-slate-800 border border-slate-300 py-3 rounded-lg font-medium hover:bg-slate-50 transition-colors flex items-center justify-center gap-2"
+      >
+        <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+          <path fill="#EA4335" d="M12 10.2v3.9h5.5c-.24 1.3-.99 2.4-2.1 3.13l3.2 2.48c1.86-1.71 2.94-4.22 2.94-7.21 0-.66-.06-1.3-.17-1.9H12z" />
+          <path fill="#34A853" d="M12 22c2.7 0 4.96-.9 6.61-2.44l-3.2-2.48c-.89.59-2.03.95-3.41.95-2.62 0-4.85-1.77-5.65-4.15l-3.31 2.56A9.98 9.98 0 0 0 12 22z" />
+          <path fill="#FBBC05" d="M6.35 13.88A5.97 5.97 0 0 1 6 12c0-.65.12-1.28.35-1.88L3.04 7.56A9.98 9.98 0 0 0 2 12c0 1.62.39 3.14 1.04 4.44l3.31-2.56z" />
+          <path fill="#4285F4" d="M12 5.97c1.47 0 2.79.5 3.83 1.49l2.87-2.87C16.95 2.96 14.7 2 12 2c-3.9 0-7.25 2.23-8.96 5.56l3.31 2.56c.8-2.38 3.03-4.15 5.65-4.15z" />
+        </svg>
+        Continue with Google
+      </button>
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <div className="w-full border-t border-slate-200" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-white px-2 text-slate-500">or sign up with code</span>
+        </div>
+      </div>
+
+      <form onSubmit={onCompleteSignup} className="space-y-3">
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700 mb-1.5 block">@wisc.edu email</span>
+          <div className="relative">
+            <Mail size={16} className="absolute left-3 top-3 text-slate-400" />
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="abc123@wisc.edu"
+              className="w-full border border-slate-300 rounded-lg pl-9 pr-3 py-2.5"
+              required
+            />
+          </div>
+        </label>
+
+        <button
+          type="button"
+          onClick={() => requestOtp.mutate({ email })}
+          disabled={requestOtp.isPending || !canRequestOtp}
+          className="w-full py-2.5 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 disabled:opacity-60"
+        >
+          {requestOtp.isPending ? 'Sending code...' : otpSent ? 'Resend code' : 'Send verification code'}
+        </button>
+
+        {otpSent && (
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800 flex items-start gap-2">
+            <CheckCircle2 size={16} className="mt-0.5" />
+            <span>Code sent. Check your inbox and complete the fields below.</span>
+          </div>
+        )}
+
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700 mb-1.5 block">Verification code</span>
+          <input
+            type="text"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder="6-digit code"
+            maxLength={6}
+            className="w-full border border-slate-300 rounded-lg px-3 py-2.5"
+            required
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700 mb-1.5 block">Login handle</span>
+          <div className="relative">
+            <UserCircle size={16} className="absolute left-3 top-3 text-slate-400" />
+            <input
+              type="text"
+              value={loginHandle}
+              onChange={(e) => setLoginHandle(e.target.value)}
+              placeholder="abc123 (optional, auto-generated if empty)"
+              className="w-full border border-slate-300 rounded-lg pl-9 pr-3 py-2.5"
+            />
+          </div>
+          <p className="text-xs text-slate-500 mt-1">Use letters, numbers, dot, underscore, or hyphen.</p>
+        </label>
+
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700 mb-1.5 block">Password</span>
+          <div className="relative">
+            <KeyRound size={16} className="absolute left-3 top-3 text-slate-400" />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="At least 8 characters"
+              minLength={8}
+              className="w-full border border-slate-300 rounded-lg pl-9 pr-3 py-2.5"
+              required
+            />
+          </div>
+        </label>
+
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700 mb-1.5 block">Confirm password</span>
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="Repeat password"
+            minLength={8}
+            className="w-full border border-slate-300 rounded-lg px-3 py-2.5"
+            required
+          />
+        </label>
+
+        <button
+          type="submit"
+          disabled={completeSignup.isPending || !canComplete}
+          className="w-full py-2.5 rounded-lg font-medium bg-slate-900 text-white hover:bg-slate-800 disabled:opacity-60"
+        >
+          {completeSignup.isPending ? 'Creating account...' : 'Create account'}
+        </button>
+      </form>
+
+      <p className="text-center text-sm text-slate-600">
+        Already have an account?{' '}
+        <Link href="/auth/signin" className="text-uw-red hover:text-uw-dark font-medium">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/components/auth/ProfileSecuritySettings.tsx
+++ b/components/auth/ProfileSecuritySettings.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { trpc } from '@/lib/trpc/client'
+
+function maskEmail(email: string): string {
+  const [local, domain] = email.split('@')
+  if (!local || !domain) return 'Hidden'
+  if (local.length <= 2) return `${local[0] || '*'}***@${domain}`
+  return `${local.slice(0, 2)}***@${domain}`
+}
+
+export function ProfileSecuritySettings() {
+  const security = trpc.auth.getSecurityProfile.useQuery()
+  const utils = trpc.useUtils()
+
+  const [loginHandle, setLoginHandle] = useState('')
+  const [recoveryEmail, setRecoveryEmail] = useState('')
+  const [recoveryCode, setRecoveryCode] = useState('')
+
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+
+  const updateHandle = trpc.auth.updateLoginHandle.useMutation({
+    onSuccess: (data) => {
+      toast.success(`Login handle updated to ${data.loginHandle}`)
+      utils.auth.getSecurityProfile.invalidate()
+    },
+    onError: (error) => toast.error(error.message),
+  })
+
+  const requestRecoveryOtp = trpc.auth.requestRecoveryEmailOtp.useMutation({
+    onSuccess: (data) => {
+      toast.success('Recovery verification code sent.')
+      if (data.devCode) {
+        toast.info(`Dev OTP: ${data.devCode}`)
+      }
+    },
+    onError: (error) => toast.error(error.message),
+  })
+
+  const verifyRecoveryOtp = trpc.auth.verifyRecoveryEmailOtp.useMutation({
+    onSuccess: () => {
+      toast.success('Recovery email linked successfully.')
+      setRecoveryCode('')
+      utils.auth.getSecurityProfile.invalidate()
+    },
+    onError: (error) => toast.error(error.message),
+  })
+
+  const setPassword = trpc.auth.setPassword.useMutation({
+    onSuccess: () => {
+      toast.success('Password updated.')
+      setCurrentPassword('')
+      setNewPassword('')
+      setConfirmPassword('')
+      utils.auth.getSecurityProfile.invalidate()
+    },
+    onError: (error) => toast.error(error.message),
+  })
+
+  const recoveryEmails = useMemo(
+    () => security.data?.emails?.filter((e) => e.type === 'RECOVERY') ?? [],
+    [security.data?.emails]
+  )
+
+  useEffect(() => {
+    if (security.data?.loginHandle && !loginHandle) {
+      setLoginHandle(security.data.loginHandle)
+    }
+  }, [security.data?.loginHandle, loginHandle])
+
+  if (security.isLoading) {
+    return (
+      <div className="bg-surface-primary rounded-xl border border-surface-tertiary p-6">
+        <h2 className="text-lg font-bold text-text-primary mb-2">Login & Security</h2>
+        <p className="text-sm text-text-secondary">Loading account security settings...</p>
+      </div>
+    )
+  }
+
+  if (security.error || !security.data) {
+    return (
+      <div className="bg-surface-primary rounded-xl border border-red-200 p-6">
+        <h2 className="text-lg font-bold text-text-primary mb-2">Login & Security</h2>
+        <p className="text-sm text-red-600">Failed to load security settings.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-surface-primary rounded-xl border border-surface-tertiary p-6 space-y-6">
+      <div>
+        <h2 className="text-lg font-bold text-text-primary">Login & Security</h2>
+        <p className="text-sm text-text-secondary mt-1">
+          Verification status: <span className="font-medium">{security.data.eligibilityStatus}</span>
+        </p>
+        {security.data.requiresRecoverySetup && (
+          <p className="text-sm text-amber-700 mt-2">
+            Add a recovery email now to keep access after graduation.
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-text-primary">Login handle</label>
+        <input
+          type="text"
+          value={loginHandle}
+          onChange={(e) => setLoginHandle(e.target.value)}
+          placeholder="Set your login handle"
+          className="w-full border border-surface-tertiary rounded-lg px-3 py-2"
+        />
+        <button
+          type="button"
+          onClick={() => updateHandle.mutate({ loginHandle: loginHandle.trim() })}
+          disabled={updateHandle.isPending || !loginHandle.trim()}
+          className="px-4 py-2 rounded-lg border border-surface-tertiary text-sm hover:bg-surface-secondary disabled:opacity-60"
+        >
+          {updateHandle.isPending ? 'Saving...' : 'Update handle'}
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-text-primary">Recovery email (non-@wisc.edu)</label>
+        <input
+          type="email"
+          value={recoveryEmail}
+          onChange={(e) => setRecoveryEmail(e.target.value)}
+          placeholder="you@gmail.com"
+          className="w-full border border-surface-tertiary rounded-lg px-3 py-2"
+        />
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => requestRecoveryOtp.mutate({ email: recoveryEmail })}
+            disabled={requestRecoveryOtp.isPending || !recoveryEmail.includes('@')}
+            className="px-4 py-2 rounded-lg border border-surface-tertiary text-sm hover:bg-surface-secondary disabled:opacity-60"
+          >
+            {requestRecoveryOtp.isPending ? 'Sending...' : 'Send verification code'}
+          </button>
+          <input
+            type="text"
+            value={recoveryCode}
+            onChange={(e) => setRecoveryCode(e.target.value)}
+            placeholder="6-digit code"
+            className="border border-surface-tertiary rounded-lg px-3 py-2 text-sm"
+          />
+          <button
+            type="button"
+            onClick={() => verifyRecoveryOtp.mutate({ email: recoveryEmail, code: recoveryCode })}
+            disabled={verifyRecoveryOtp.isPending || !recoveryEmail.includes('@') || recoveryCode.length !== 6}
+            className="px-4 py-2 rounded-lg bg-uw-red text-white text-sm hover:bg-uw-dark disabled:opacity-60"
+          >
+            {verifyRecoveryOtp.isPending ? 'Verifying...' : 'Verify recovery email'}
+          </button>
+        </div>
+
+        {recoveryEmails.length > 0 && (
+          <p className="text-xs text-text-secondary">
+            Linked recovery emails: {recoveryEmails.map((email) => maskEmail(email.email)).join(', ')}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-text-primary">Password</label>
+        {security.data.hasPassword && (
+          <input
+            type="password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            placeholder="Current password"
+            className="w-full border border-surface-tertiary rounded-lg px-3 py-2"
+          />
+        )}
+        <input
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          placeholder="New password (min 8)"
+          className="w-full border border-surface-tertiary rounded-lg px-3 py-2"
+        />
+        <input
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          placeholder="Confirm new password"
+          className="w-full border border-surface-tertiary rounded-lg px-3 py-2"
+        />
+        <button
+          type="button"
+          onClick={() => {
+            if (newPassword !== confirmPassword) {
+              toast.error('Passwords do not match.')
+              return
+            }
+            setPassword.mutate({
+              currentPassword: security.data.hasPassword ? currentPassword : undefined,
+              newPassword,
+            })
+          }}
+          disabled={
+            setPassword.isPending ||
+            newPassword.length < 8 ||
+            confirmPassword.length < 8 ||
+            (security.data.hasPassword && !currentPassword)
+          }
+          className="px-4 py-2 rounded-lg bg-slate-900 text-white text-sm hover:bg-slate-800 disabled:opacity-60"
+        >
+          {setPassword.isPending ? 'Saving...' : security.data.hasPassword ? 'Change password' : 'Set password'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/lib/authIdentity.ts
+++ b/lib/authIdentity.ts
@@ -1,0 +1,60 @@
+export const HANDLE_REGEX = /^[a-z0-9](?:[a-z0-9._-]{1,30}[a-z0-9])?$/i
+
+type HandleLookupClient = {
+  user: {
+    findUnique: (args: {
+      where: { loginHandleNormalized: string }
+      select: { id: true }
+    }) => Promise<{ id: string } | null>
+  }
+}
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+export function isWiscEmail(email: string): boolean {
+  return normalizeEmail(email).endsWith('@wisc.edu')
+}
+
+export function normalizeHandle(handle: string): string {
+  return handle.trim().toLowerCase()
+}
+
+export function isValidHandle(handle: string): boolean {
+  const normalized = normalizeHandle(handle)
+  return HANDLE_REGEX.test(normalized)
+}
+
+export function suggestHandleFromEmail(email: string): string {
+  const normalizedEmail = normalizeEmail(email)
+  const local = normalizedEmail.split('@')[0] || 'badger'
+  const cleaned = local.replace(/[^a-z0-9._-]/gi, '').replace(/^[._-]+|[._-]+$/g, '')
+  const fallback = cleaned.length >= 3 ? cleaned : `badger${Math.floor(Math.random() * 1000)}`
+  return fallback.slice(0, 32).toLowerCase()
+}
+
+export async function resolveUniqueHandle(
+  prisma: HandleLookupClient,
+  desiredHandle: string
+): Promise<string> {
+  const base = normalizeHandle(desiredHandle)
+  const seed = base.length > 0 ? base : 'badger'
+
+  let candidate = seed.slice(0, 32)
+  for (let suffix = 0; suffix < 1000; suffix += 1) {
+    if (suffix > 0) {
+      const suffixStr = suffix.toString()
+      const maxBaseLen = 32 - suffixStr.length
+      candidate = `${seed.slice(0, Math.max(1, maxBaseLen))}${suffixStr}`
+    }
+
+    const exists = await prisma.user.findUnique({
+      where: { loginHandleNormalized: candidate },
+      select: { id: true },
+    })
+    if (!exists) return candidate
+  }
+
+  return `${seed.slice(0, 27)}${Date.now().toString().slice(-5)}`
+}

--- a/lib/mailer.ts
+++ b/lib/mailer.ts
@@ -1,0 +1,43 @@
+import nodemailer from 'nodemailer'
+
+interface AuthMailInput {
+  to: string
+  subject: string
+  text: string
+  html?: string
+}
+
+function getTransport() {
+  const host = process.env.SMTP_HOST
+  const port = Number(process.env.SMTP_PORT || '587')
+  const user = process.env.SMTP_USER
+  const pass = process.env.SMTP_PASS
+
+  if (!host || !user || !pass) {
+    if (process.env.NODE_ENV === 'development') return null
+    throw new Error('SMTP is not configured')
+  }
+
+  return nodemailer.createTransport({
+    host,
+    port,
+    secure: port === 465,
+    auth: { user, pass },
+  })
+}
+
+export async function sendAuthMail(input: AuthMailInput): Promise<void> {
+  const transport = getTransport()
+  if (!transport) {
+    console.log('[DEV MAIL]', input)
+    return
+  }
+
+  await transport.sendMail({
+    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    to: input.to,
+    subject: input.subject,
+    text: input.text,
+    html: input.html,
+  })
+}

--- a/lib/otp.ts
+++ b/lib/otp.ts
@@ -1,0 +1,18 @@
+import { createHmac, randomInt } from 'crypto'
+
+function getOtpSecret(): string {
+  const otpSecret = process.env.AUTH_OTP_SECRET || process.env.AUTH_SECRET
+  if (!otpSecret) {
+    throw new Error('Missing AUTH_OTP_SECRET (or AUTH_SECRET fallback) for OTP hashing')
+  }
+  return otpSecret
+}
+
+export function generateOtpCode(): string {
+  return randomInt(100000, 1000000).toString()
+}
+
+export function hashOtp({ purpose, emailNormalized, code }: { purpose: string; emailNormalized: string; code: string }): string {
+  const payload = `${purpose}:${emailNormalized}:${code}`
+  return createHmac('sha256', getOtpSecret()).update(payload).digest('hex')
+}

--- a/lib/password.ts
+++ b/lib/password.ts
@@ -1,0 +1,33 @@
+import { randomBytes, scrypt as _scrypt, timingSafeEqual } from 'crypto'
+import { promisify } from 'util'
+
+const scrypt = promisify(_scrypt)
+const KEY_LENGTH = 64
+
+function getPepper(): string {
+  const pepper = process.env.AUTH_PASSWORD_PEPPER || process.env.AUTH_SECRET
+  if (!pepper) {
+    throw new Error('Missing AUTH_PASSWORD_PEPPER (or AUTH_SECRET fallback) for password hashing')
+  }
+  return pepper
+}
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(16)
+  const peppered = `${password}:${getPepper()}`
+  const derived = (await scrypt(peppered, salt, KEY_LENGTH)) as Buffer
+  return `scrypt$${salt.toString('hex')}$${derived.toString('hex')}`
+}
+
+export async function verifyPassword(password: string, hash: string): Promise<boolean> {
+  const parts = hash.split('$')
+  if (parts.length !== 3 || parts[0] !== 'scrypt') return false
+
+  const salt = Buffer.from(parts[1], 'hex')
+  const expected = Buffer.from(parts[2], 'hex')
+  const peppered = `${password}:${getPepper()}`
+  const derived = (await scrypt(peppered, salt, expected.length)) as Buffer
+
+  if (derived.length !== expected.length) return false
+  return timingSafeEqual(derived, expected)
+}

--- a/prisma/migrations/20260208195739_add_credentials_auth_and_identity_models/migration.sql
+++ b/prisma/migrations/20260208195739_add_credentials_auth_and_identity_models/migration.sql
@@ -1,0 +1,124 @@
+-- CreateEnum
+CREATE TYPE "UserEmailType" AS ENUM ('UNIVERSITY', 'RECOVERY');
+
+-- CreateEnum
+CREATE TYPE "OtpPurpose" AS ENUM ('REGISTER_WISC', 'LINK_RECOVERY', 'RESET_PASSWORD');
+
+-- CreateEnum
+CREATE TYPE "EligibilityStatus" AS ENUM ('UNVERIFIED', 'STUDENT_VERIFIED', 'ALUMNI_VERIFIED');
+
+-- AlterTable
+ALTER TABLE "User"
+  ADD COLUMN "eligibilityStatus" "EligibilityStatus" NOT NULL DEFAULT 'UNVERIFIED',
+  ADD COLUMN "firstVerifiedAt" TIMESTAMP(3),
+  ADD COLUMN "lastWiscVerifiedAt" TIMESTAMP(3),
+  ADD COLUMN "loginHandle" TEXT,
+  ADD COLUMN "loginHandleNormalized" TEXT,
+  ADD COLUMN "requiresRecoverySetup" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "UserEmail" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "emailNormalized" TEXT NOT NULL,
+    "type" "UserEmailType" NOT NULL,
+    "isVerified" BOOLEAN NOT NULL DEFAULT false,
+    "verifiedAt" TIMESTAMP(3),
+    "canLogin" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserEmail_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserCredential" (
+    "userId" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "passwordUpdatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "failedAttempts" INTEGER NOT NULL DEFAULT 0,
+    "lockedUntil" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserCredential_pkey" PRIMARY KEY ("userId")
+);
+
+-- CreateTable
+CREATE TABLE "EmailOtpChallenge" (
+    "id" TEXT NOT NULL,
+    "emailNormalized" TEXT NOT NULL,
+    "purpose" "OtpPurpose" NOT NULL,
+    "codeHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "attemptsLeft" INTEGER NOT NULL DEFAULT 5,
+    "lastSentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "consumedAt" TIMESTAMP(3),
+    "ipHash" TEXT,
+    "userAgentHash" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EmailOtpChallenge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserEmail_emailNormalized_key" ON "UserEmail"("emailNormalized");
+
+-- CreateIndex
+CREATE INDEX "UserEmail_userId_idx" ON "UserEmail"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserEmail_userId_type_idx" ON "UserEmail"("userId", "type");
+
+-- CreateIndex
+CREATE INDEX "EmailOtpChallenge_emailNormalized_purpose_createdAt_idx" ON "EmailOtpChallenge"("emailNormalized", "purpose", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "EmailOtpChallenge_expiresAt_idx" ON "EmailOtpChallenge"("expiresAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_loginHandle_key" ON "User"("loginHandle");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_loginHandleNormalized_key" ON "User"("loginHandleNormalized");
+
+-- AddForeignKey
+ALTER TABLE "UserEmail" ADD CONSTRAINT "UserEmail_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserCredential" ADD CONSTRAINT "UserCredential_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Backfill existing users as verified identities
+UPDATE "User"
+SET
+  "eligibilityStatus" = CASE WHEN lower("email") LIKE '%@wisc.edu' THEN 'STUDENT_VERIFIED'::"EligibilityStatus" ELSE 'UNVERIFIED'::"EligibilityStatus" END,
+  "firstVerifiedAt" = CASE WHEN lower("email") LIKE '%@wisc.edu' THEN COALESCE("firstVerifiedAt", "emailVerified", "createdAt") ELSE "firstVerifiedAt" END,
+  "lastWiscVerifiedAt" = CASE WHEN lower("email") LIKE '%@wisc.edu' THEN COALESCE("lastWiscVerifiedAt", "emailVerified", "createdAt") ELSE "lastWiscVerifiedAt" END,
+  "requiresRecoverySetup" = CASE WHEN lower("email") LIKE '%@wisc.edu' THEN true ELSE "requiresRecoverySetup" END;
+
+INSERT INTO "UserEmail" (
+  "id",
+  "userId",
+  "email",
+  "emailNormalized",
+  "type",
+  "isVerified",
+  "verifiedAt",
+  "canLogin",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  'legacy_' || u."id",
+  u."id",
+  u."email",
+  lower(u."email"),
+  CASE WHEN lower(u."email") LIKE '%@wisc.edu' THEN 'UNIVERSITY'::"UserEmailType" ELSE 'RECOVERY'::"UserEmailType" END,
+  true,
+  COALESCE(u."emailVerified", now()),
+  true,
+  now(),
+  now()
+FROM "User" u
+ON CONFLICT ("emailNormalized") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,29 +42,82 @@ model VerificationToken {
 }
 
 model User {
-  id            String                 @id @default(cuid())
-  email         String                 @unique
-  emailVerified DateTime?
-  name          String?
-  nickname      String?
-  image         String?
-  role          UserRole               @default(STUDENT)
-  createdAt     DateTime               @default(now())
-  level         Int                    @default(0)
-  title         String?
-  xp            Int                    @default(0)
-  accounts      Account[]
-  comments      Comment[]
-  reports       Report[]               @relation("ReportedBy")
-  reviews       Review[]
-  savedCourses  SavedCourse[]
-  sessions      Session[]
-  transcript    StudentCourseHistory[]
-  votes         Vote[]
-  auditLogs     AuditLog[]             @relation("AuditActor")
-  bans          UserBan[]              @relation("BannedUser")
-  bansIssued    UserBan[]              @relation("BanIssuer")
-  resolvedReports Report[]             @relation("ResolvedBy")
+  id                    String                 @id @default(cuid())
+  email                 String                 @unique
+  emailVerified         DateTime?
+  loginHandle           String?                @unique
+  loginHandleNormalized String?                @unique
+  name                  String?
+  nickname              String?
+  image                 String?
+  role                  UserRole               @default(STUDENT)
+  eligibilityStatus     EligibilityStatus      @default(UNVERIFIED)
+  firstVerifiedAt       DateTime?
+  lastWiscVerifiedAt    DateTime?
+  requiresRecoverySetup Boolean                @default(false)
+  createdAt             DateTime               @default(now())
+  level                 Int                    @default(0)
+  title                 String?
+  xp                    Int                    @default(0)
+  accounts              Account[]
+  emails                UserEmail[]
+  credential            UserCredential?
+  comments              Comment[]
+  reports               Report[]               @relation("ReportedBy")
+  reviews               Review[]
+  savedCourses          SavedCourse[]
+  sessions              Session[]
+  transcript            StudentCourseHistory[]
+  votes                 Vote[]
+  auditLogs             AuditLog[]             @relation("AuditActor")
+  bans                  UserBan[]              @relation("BannedUser")
+  bansIssued            UserBan[]              @relation("BanIssuer")
+  resolvedReports       Report[]               @relation("ResolvedBy")
+}
+
+model UserEmail {
+  id              String        @id @default(cuid())
+  userId          String
+  email           String
+  emailNormalized String        @unique
+  type            UserEmailType
+  isVerified      Boolean       @default(false)
+  verifiedAt      DateTime?
+  canLogin        Boolean       @default(false)
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+  user            User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([userId, type])
+}
+
+model UserCredential {
+  userId            String    @id
+  passwordHash      String
+  passwordUpdatedAt DateTime  @default(now())
+  failedAttempts    Int       @default(0)
+  lockedUntil       DateTime?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model EmailOtpChallenge {
+  id              String     @id @default(cuid())
+  emailNormalized String
+  purpose         OtpPurpose
+  codeHash        String
+  expiresAt       DateTime
+  attemptsLeft    Int        @default(5)
+  lastSentAt      DateTime   @default(now())
+  consumedAt      DateTime?
+  ipHash          String?
+  userAgentHash   String?
+  createdAt       DateTime   @default(now())
+
+  @@index([emailNormalized, purpose, createdAt])
+  @@index([expiresAt])
 }
 
 model School {
@@ -182,34 +235,34 @@ model GradeDistribution {
 }
 
 model Review {
-  id              String     @id @default(cuid())
-  term            String
-  title           String?
-  gradeReceived   Grade?
-  contentRating   String
-  teachingRating  String
-  gradingRating   String
-  workloadRating  String
-  contentComment  String?
-  teachingComment String?
-  gradingComment  String?
+  id                    String     @id @default(cuid())
+  term                  String
+  title                 String?
+  gradeReceived         Grade?
+  contentRating         String
+  teachingRating        String
+  gradingRating         String
+  workloadRating        String
+  contentComment        String?
+  teachingComment       String?
+  gradingComment        String?
   workloadComment       String?
-  recommendInstructor   String?    // 'yes' | 'no' | 'neutral'
+  recommendInstructor   String? // 'yes' | 'no' | 'neutral'
   assessments           String?
-  tags            String?
-  resourceLink    String?
-  instructorId    String
-  courseId        String
-  authorId        String
-  createdAt       DateTime   @default(now())
-  comments        Comment[]
-  reports         Report[]
-  author          User       @relation(fields: [authorId], references: [id])
-  course          Course     @relation(fields: [courseId], references: [id])
-  instructor      Instructor @relation(fields: [instructorId], references: [id])
-  votes           Vote[]
-  isAnonymous           Boolean   @default(false)
-  showRankWhenAnonymous Boolean   @default(false)
+  tags                  String?
+  resourceLink          String?
+  instructorId          String
+  courseId              String
+  authorId              String
+  createdAt             DateTime   @default(now())
+  comments              Comment[]
+  reports               Report[]
+  author                User       @relation(fields: [authorId], references: [id])
+  course                Course     @relation(fields: [courseId], references: [id])
+  instructor            Instructor @relation(fields: [instructorId], references: [id])
+  votes                 Vote[]
+  isAnonymous           Boolean    @default(false)
+  showRankWhenAnonymous Boolean    @default(false)
 
   // P1 Fix: Prevent duplicate reviews via DB constraint (one review per user per course+instructor)
   @@unique([authorId, courseId, instructorId])
@@ -263,10 +316,10 @@ model InstructorAlias {
   instructor   Instructor @relation(fields: [instructorId], references: [id], onDelete: Cascade)
   createdAt    DateTime   @default(now())
 
+  @@unique([aliasKey, instructorId])
   @@index([aliasKey])
   @@index([courseId, term])
   @@index([instructorId])
-  @@unique([aliasKey, instructorId])
 }
 
 model CourseInstructor {
@@ -299,7 +352,7 @@ model Report {
   createdAt    DateTime  @default(now())
   resolvedById String?
   resolvedAt   DateTime?
-  resolution   String?   // "approved" | "rejected" | "escalated"
+  resolution   String? // "approved" | "rejected" | "escalated"
   reporter     User      @relation("ReportedBy", fields: [reporterId], references: [id])
   review       Review    @relation(fields: [reviewId], references: [id])
   resolvedBy   User?     @relation("ResolvedBy", fields: [resolvedById], references: [id])
@@ -326,10 +379,27 @@ enum UserRole {
   ADMIN
 }
 
+enum UserEmailType {
+  UNIVERSITY
+  RECOVERY
+}
+
+enum OtpPurpose {
+  REGISTER_WISC
+  LINK_RECOVERY
+  RESET_PASSWORD
+}
+
+enum EligibilityStatus {
+  UNVERIFIED
+  STUDENT_VERIFIED
+  ALUMNI_VERIFIED
+}
+
 model AuditLog {
   id         String   @id @default(cuid())
-  action     String   // e.g. "RESOLVE_REPORT", "DELETE_REVIEW", "BAN_USER", "CHANGE_ROLE"
-  targetType String   // e.g. "Report", "Review", "User"
+  action     String // e.g. "RESOLVE_REPORT", "DELETE_REVIEW", "BAN_USER", "CHANGE_ROLE"
+  targetType String // e.g. "Report", "Review", "User"
   targetId   String
   details    Json?
   actorId    String
@@ -342,15 +412,15 @@ model AuditLog {
 }
 
 model UserBan {
-  id        String    @id @default(cuid())
-  userId    String
-  reason    String
+  id         String    @id @default(cuid())
+  userId     String
+  reason     String
   bannedById String
-  expiresAt DateTime?
-  active    Boolean   @default(true)
-  createdAt DateTime  @default(now())
-  user      User      @relation("BannedUser", fields: [userId], references: [id])
-  bannedBy  User      @relation("BanIssuer", fields: [bannedById], references: [id])
+  expiresAt  DateTime?
+  active     Boolean   @default(true)
+  createdAt  DateTime  @default(now())
+  user       User      @relation("BannedUser", fields: [userId], references: [id])
+  bannedBy   User      @relation("BanIssuer", fields: [bannedById], references: [id])
 
   @@index([userId, active])
 }

--- a/server/api/root.ts
+++ b/server/api/root.ts
@@ -5,6 +5,7 @@ import { commentRouter } from './routers/comment'
 import { instructorRouter } from './routers/instructor'
 import { userRouter } from './routers/user'
 import { adminRouter } from './routers/admin'
+import { authRouter } from './routers/auth'
 
 export const appRouter = router({
   course: courseRouter,
@@ -13,6 +14,7 @@ export const appRouter = router({
   instructor: instructorRouter,
   user: userRouter,
   admin: adminRouter,
+  auth: authRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/server/api/routers/auth.ts
+++ b/server/api/routers/auth.ts
@@ -1,0 +1,686 @@
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { verifyPassword, hashPassword } from '@/lib/password'
+import {
+  normalizeEmail,
+  isWiscEmail,
+  isValidHandle,
+  normalizeHandle,
+  resolveUniqueHandle,
+  suggestHandleFromEmail,
+} from '@/lib/authIdentity'
+import { generateOtpCode, hashOtp } from '@/lib/otp'
+import { sendAuthMail } from '@/lib/mailer'
+import { protectedProcedure, publicProcedure, router } from '../trpc/trpc'
+import type { Prisma } from '@prisma/client'
+
+const OTP_TTL_MINUTES = 10
+const OTP_SEND_COOLDOWN_SECONDS = 60
+const OTP_MAX_PER_HOUR = 10
+const PASSWORD_MAX_FAILED_ATTEMPTS = 5
+const PASSWORD_LOCK_MINUTES = 15
+
+const ALLOWED_ELIGIBILITY = ['STUDENT_VERIFIED', 'ALUMNI_VERIFIED'] as const
+
+type OtpPurpose = 'REGISTER_WISC' | 'LINK_RECOVERY' | 'RESET_PASSWORD'
+type Tx = Prisma.TransactionClient
+
+function getRequestFingerprint(ip: string | undefined, userAgent: string | undefined) {
+  const ipHash = ip ? hashOtp({ purpose: 'ip', emailNormalized: ip, code: 'fingerprint' }) : null
+  const userAgentHash = userAgent
+    ? hashOtp({ purpose: 'ua', emailNormalized: userAgent, code: 'fingerprint' })
+    : null
+  return { ipHash, userAgentHash }
+}
+
+async function assertSendAllowed(prisma: Tx, emailNormalized: string, purpose: OtpPurpose) {
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
+  const latest = await prisma.emailOtpChallenge.findFirst({
+    where: { emailNormalized, purpose },
+    orderBy: { createdAt: 'desc' },
+    select: { lastSentAt: true },
+  })
+
+  if (latest) {
+    const seconds = (Date.now() - latest.lastSentAt.getTime()) / 1000
+    if (seconds < OTP_SEND_COOLDOWN_SECONDS) {
+      throw new TRPCError({
+        code: 'TOO_MANY_REQUESTS',
+        message: 'Please wait before requesting another code.',
+      })
+    }
+  }
+
+  const count = await prisma.emailOtpChallenge.count({
+    where: {
+      emailNormalized,
+      purpose,
+      createdAt: { gte: oneHourAgo },
+    },
+  })
+
+  if (count >= OTP_MAX_PER_HOUR) {
+    throw new TRPCError({
+      code: 'TOO_MANY_REQUESTS',
+      message: 'Too many verification attempts. Try again later.',
+    })
+  }
+}
+
+async function createOtpChallenge({
+  prisma,
+  emailNormalized,
+  purpose,
+  ip,
+  userAgent,
+}: {
+  prisma: Tx
+  emailNormalized: string
+  purpose: OtpPurpose
+  ip?: string
+  userAgent?: string
+}) {
+  await assertSendAllowed(prisma, emailNormalized, purpose)
+
+  const code = generateOtpCode()
+  const codeHash = hashOtp({ purpose, emailNormalized, code })
+  const expiresAt = new Date(Date.now() + OTP_TTL_MINUTES * 60 * 1000)
+  const { ipHash, userAgentHash } = getRequestFingerprint(ip, userAgent)
+
+  await prisma.emailOtpChallenge.create({
+    data: {
+      emailNormalized,
+      purpose,
+      codeHash,
+      expiresAt,
+      attemptsLeft: 5,
+      ipHash,
+      userAgentHash,
+    },
+  })
+
+  return { code, expiresAt }
+}
+
+async function verifyOtpCode({
+  prisma,
+  emailNormalized,
+  purpose,
+  code,
+}: {
+  prisma: Tx
+  emailNormalized: string
+  purpose: OtpPurpose
+  code: string
+}) {
+  const challenge = await prisma.emailOtpChallenge.findFirst({
+    where: {
+      emailNormalized,
+      purpose,
+      consumedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  if (!challenge) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid or expired verification code.' })
+  }
+
+  if (challenge.attemptsLeft <= 0) {
+    throw new TRPCError({
+      code: 'TOO_MANY_REQUESTS',
+      message: 'Verification attempts exceeded. Request a new code.',
+    })
+  }
+
+  const expectedHash = hashOtp({ purpose, emailNormalized, code })
+  if (challenge.codeHash !== expectedHash) {
+    const attemptsLeft = challenge.attemptsLeft - 1
+    await prisma.emailOtpChallenge.update({
+      where: { id: challenge.id },
+      data: {
+        attemptsLeft,
+        ...(attemptsLeft <= 0 ? { consumedAt: new Date() } : {}),
+      },
+    })
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid or expired verification code.' })
+  }
+
+  await prisma.emailOtpChallenge.update({
+    where: { id: challenge.id },
+    data: { consumedAt: new Date() },
+  })
+}
+
+async function resolveUserByIdentifier(prisma: Tx, identifierRaw: string) {
+  const identifier = identifierRaw.trim()
+  if (!identifier) return null
+
+  if (identifier.includes('@')) {
+    const emailNormalized = normalizeEmail(identifier)
+    const emailIdentity = await prisma.userEmail.findUnique({
+      where: { emailNormalized },
+      include: {
+        user: {
+          include: {
+            credential: true,
+          },
+        },
+      },
+    })
+
+    if (!emailIdentity || !emailIdentity.isVerified || !emailIdentity.canLogin) return null
+    return { user: emailIdentity.user, loginEmail: emailIdentity.email }
+  }
+
+  const handleNormalized = normalizeHandle(identifier)
+  const user = await prisma.user.findUnique({
+    where: { loginHandleNormalized: handleNormalized },
+    include: { credential: true },
+  })
+
+  if (!user) return null
+  return { user, loginEmail: user.email }
+}
+
+async function findLoginEmailForUser(prisma: Tx, userId: string) {
+  const recoveryEmail = await prisma.userEmail.findFirst({
+    where: {
+      userId,
+      type: 'RECOVERY',
+      isVerified: true,
+      canLogin: true,
+    },
+  })
+  if (recoveryEmail) return recoveryEmail
+
+  return prisma.userEmail.findFirst({
+    where: {
+      userId,
+      isVerified: true,
+      canLogin: true,
+    },
+    orderBy: { type: 'asc' },
+  })
+}
+
+export const authRouter = router({
+  requestWiscSignupOtp: publicProcedure
+    .input(z.object({ email: z.string().email() }))
+    .mutation(async ({ ctx, input }) => {
+      const emailNormalized = normalizeEmail(input.email)
+      if (!isWiscEmail(emailNormalized)) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Only @wisc.edu emails can be verified for signup.',
+        })
+      }
+
+      const { code } = await createOtpChallenge({
+        prisma: ctx.prisma,
+        emailNormalized,
+        purpose: 'REGISTER_WISC',
+        ip: ctx.requestMeta?.ip,
+        userAgent: ctx.requestMeta?.userAgent,
+      })
+
+      await sendAuthMail({
+        to: emailNormalized,
+        subject: 'MadSpace verification code',
+        text: `Your verification code is ${code}. It expires in ${OTP_TTL_MINUTES} minutes.`,
+      })
+
+      return {
+        success: true,
+        ...(process.env.NODE_ENV === 'development' ? { devCode: code } : {}),
+      }
+    }),
+
+  completeWiscSignup: publicProcedure
+    .input(
+      z.object({
+        email: z.string().email(),
+        code: z.string().length(6),
+        password: z.string().min(8).max(128),
+        loginHandle: z.string().min(3).max(32).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const emailNormalized = normalizeEmail(input.email)
+      if (!isWiscEmail(emailNormalized)) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Only @wisc.edu emails can be used for registration.',
+        })
+      }
+
+      await verifyOtpCode({
+        prisma: ctx.prisma,
+        emailNormalized,
+        purpose: 'REGISTER_WISC',
+        code: input.code,
+      })
+
+      const passwordHash = await hashPassword(input.password)
+
+      const result = await ctx.prisma.$transaction(async (tx) => {
+        const existingIdentity = await tx.userEmail.findUnique({
+          where: { emailNormalized },
+          include: { user: true },
+        })
+
+        const user = existingIdentity?.user
+          ? await tx.user.update({
+              where: { id: existingIdentity.user.id },
+              data: {
+                email: emailNormalized,
+                emailVerified: existingIdentity.user.emailVerified || new Date(),
+                eligibilityStatus: 'STUDENT_VERIFIED',
+                firstVerifiedAt: existingIdentity.user.firstVerifiedAt || new Date(),
+                lastWiscVerifiedAt: new Date(),
+                requiresRecoverySetup: true,
+              },
+            })
+          : await tx.user.create({
+              data: {
+                email: emailNormalized,
+                emailVerified: new Date(),
+                eligibilityStatus: 'STUDENT_VERIFIED',
+                firstVerifiedAt: new Date(),
+                lastWiscVerifiedAt: new Date(),
+                requiresRecoverySetup: true,
+              },
+            })
+
+        const desiredHandleRaw = input.loginHandle?.trim() || suggestHandleFromEmail(emailNormalized)
+        if (!isValidHandle(desiredHandleRaw)) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Login handle can only use letters, numbers, ., _, - and must be 3-32 chars.',
+          })
+        }
+
+        const handleNormalized = normalizeHandle(desiredHandleRaw)
+        const holder = await tx.user.findUnique({
+          where: { loginHandleNormalized: handleNormalized },
+          select: { id: true },
+        })
+        const resolvedHandle =
+          !holder || holder.id === user.id
+            ? handleNormalized
+            : await resolveUniqueHandle(tx, handleNormalized)
+
+        await tx.user.update({
+          where: { id: user.id },
+          data: {
+            loginHandle: resolvedHandle,
+            loginHandleNormalized: resolvedHandle,
+          },
+        })
+
+        await tx.userEmail.upsert({
+          where: { emailNormalized },
+          update: {
+            email: emailNormalized,
+            type: 'UNIVERSITY',
+            isVerified: true,
+            verifiedAt: new Date(),
+            canLogin: true,
+            userId: user.id,
+          },
+          create: {
+            userId: user.id,
+            email: emailNormalized,
+            emailNormalized,
+            type: 'UNIVERSITY',
+            isVerified: true,
+            verifiedAt: new Date(),
+            canLogin: true,
+          },
+        })
+
+        await tx.userCredential.upsert({
+          where: { userId: user.id },
+          update: {
+            passwordHash,
+            passwordUpdatedAt: new Date(),
+            failedAttempts: 0,
+            lockedUntil: null,
+          },
+          create: {
+            userId: user.id,
+            passwordHash,
+            passwordUpdatedAt: new Date(),
+          },
+        })
+
+        return {
+          userId: user.id,
+          loginHandle: resolvedHandle,
+          email: emailNormalized,
+        }
+      })
+
+      return { success: true, ...result }
+    }),
+
+  requestRecoveryEmailOtp: protectedProcedure
+    .input(z.object({ email: z.string().email() }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id
+      const emailNormalized = normalizeEmail(input.email)
+
+      if (isWiscEmail(emailNormalized)) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Recovery email must be non-@wisc.edu.' })
+      }
+
+      const existing = await ctx.prisma.userEmail.findUnique({ where: { emailNormalized } })
+      if (existing && existing.userId !== userId) {
+        throw new TRPCError({ code: 'CONFLICT', message: 'This email is already linked to another account.' })
+      }
+
+      const { code } = await createOtpChallenge({
+        prisma: ctx.prisma,
+        emailNormalized,
+        purpose: 'LINK_RECOVERY',
+        ip: ctx.requestMeta?.ip,
+        userAgent: ctx.requestMeta?.userAgent,
+      })
+
+      await sendAuthMail({
+        to: emailNormalized,
+        subject: 'MadSpace recovery email verification code',
+        text: `Your recovery email verification code is ${code}. It expires in ${OTP_TTL_MINUTES} minutes.`,
+      })
+
+      return {
+        success: true,
+        ...(process.env.NODE_ENV === 'development' ? { devCode: code } : {}),
+      }
+    }),
+
+  verifyRecoveryEmailOtp: protectedProcedure
+    .input(z.object({ email: z.string().email(), code: z.string().length(6) }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id
+      const emailNormalized = normalizeEmail(input.email)
+
+      if (isWiscEmail(emailNormalized)) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Recovery email must be non-@wisc.edu.' })
+      }
+
+      await verifyOtpCode({
+        prisma: ctx.prisma,
+        emailNormalized,
+        purpose: 'LINK_RECOVERY',
+        code: input.code,
+      })
+
+      const existing = await ctx.prisma.userEmail.findUnique({ where: { emailNormalized } })
+      if (existing && existing.userId !== userId) {
+        throw new TRPCError({ code: 'CONFLICT', message: 'This email is already linked to another account.' })
+      }
+
+      await ctx.prisma.$transaction(async (tx) => {
+        await tx.userEmail.upsert({
+          where: { emailNormalized },
+          update: {
+            userId,
+            email: emailNormalized,
+            type: 'RECOVERY',
+            isVerified: true,
+            verifiedAt: new Date(),
+            canLogin: true,
+          },
+          create: {
+            userId,
+            email: emailNormalized,
+            emailNormalized,
+            type: 'RECOVERY',
+            isVerified: true,
+            verifiedAt: new Date(),
+            canLogin: true,
+          },
+        })
+
+        const user = await tx.user.findUnique({
+          where: { id: userId },
+          select: { eligibilityStatus: true },
+        })
+
+        await tx.user.update({
+          where: { id: userId },
+          data: {
+            requiresRecoverySetup: false,
+            eligibilityStatus:
+              user?.eligibilityStatus === 'UNVERIFIED' ? 'ALUMNI_VERIFIED' : user?.eligibilityStatus,
+          },
+        })
+      })
+
+      return { success: true }
+    }),
+
+  requestPasswordResetOtp: publicProcedure
+    .input(z.object({ identifier: z.string().min(3).max(320) }))
+    .mutation(async ({ ctx, input }) => {
+      const record = await resolveUserByIdentifier(ctx.prisma, input.identifier)
+      if (!record?.user?.id) {
+        return { success: true }
+      }
+
+      if (!ALLOWED_ELIGIBILITY.includes(record.user.eligibilityStatus as (typeof ALLOWED_ELIGIBILITY)[number])) {
+        return { success: true }
+      }
+
+      const loginEmail = await findLoginEmailForUser(ctx.prisma, record.user.id)
+      if (!loginEmail) {
+        return { success: true }
+      }
+
+      const { code } = await createOtpChallenge({
+        prisma: ctx.prisma,
+        emailNormalized: loginEmail.emailNormalized,
+        purpose: 'RESET_PASSWORD',
+        ip: ctx.requestMeta?.ip,
+        userAgent: ctx.requestMeta?.userAgent,
+      })
+
+      await sendAuthMail({
+        to: loginEmail.email,
+        subject: 'MadSpace password reset code',
+        text: `Your password reset code is ${code}. It expires in ${OTP_TTL_MINUTES} minutes.`,
+      })
+
+      return {
+        success: true,
+        ...(process.env.NODE_ENV === 'development' ? { devCode: code, sentTo: loginEmail.email } : {}),
+      }
+    }),
+
+  resetPasswordWithOtp: publicProcedure
+    .input(
+      z.object({
+        email: z.string().email(),
+        code: z.string().length(6),
+        password: z.string().min(8).max(128),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const emailNormalized = normalizeEmail(input.email)
+
+      await verifyOtpCode({
+        prisma: ctx.prisma,
+        emailNormalized,
+        purpose: 'RESET_PASSWORD',
+        code: input.code,
+      })
+
+      const userEmail = await ctx.prisma.userEmail.findUnique({
+        where: { emailNormalized },
+        include: { user: true },
+      })
+
+      if (!userEmail || !userEmail.canLogin || !userEmail.isVerified) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Unable to reset password for this email.' })
+      }
+
+      const passwordHash = await hashPassword(input.password)
+      await ctx.prisma.userCredential.upsert({
+        where: { userId: userEmail.userId },
+        update: {
+          passwordHash,
+          passwordUpdatedAt: new Date(),
+          failedAttempts: 0,
+          lockedUntil: null,
+        },
+        create: {
+          userId: userEmail.userId,
+          passwordHash,
+          passwordUpdatedAt: new Date(),
+        },
+      })
+
+      return { success: true }
+    }),
+
+  getSecurityProfile: protectedProcedure.query(async ({ ctx }) => {
+    const userId = ctx.session.user.id
+    const user = await ctx.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        loginHandle: true,
+        loginHandleNormalized: true,
+        requiresRecoverySetup: true,
+        eligibilityStatus: true,
+        emails: {
+          orderBy: [{ type: 'asc' }, { createdAt: 'asc' }],
+          select: {
+            id: true,
+            email: true,
+            type: true,
+            isVerified: true,
+            canLogin: true,
+            verifiedAt: true,
+          },
+        },
+        credential: {
+          select: {
+            passwordUpdatedAt: true,
+          },
+        },
+      },
+    })
+
+    if (!user) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found.' })
+    }
+
+    return {
+      loginHandle: user.loginHandle,
+      loginHandleNormalized: user.loginHandleNormalized,
+      requiresRecoverySetup: user.requiresRecoverySetup,
+      eligibilityStatus: user.eligibilityStatus,
+      emails: user.emails,
+      hasPassword: !!user.credential,
+      passwordUpdatedAt: user.credential?.passwordUpdatedAt ?? null,
+    }
+  }),
+
+  updateLoginHandle: protectedProcedure
+    .input(z.object({ loginHandle: z.string().min(3).max(32) }))
+    .mutation(async ({ ctx, input }) => {
+      const normalized = normalizeHandle(input.loginHandle)
+      if (!isValidHandle(normalized)) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Login handle can only use letters, numbers, ., _, - and must be 3-32 chars.',
+        })
+      }
+
+      const userId = ctx.session.user.id
+      const holder = await ctx.prisma.user.findUnique({
+        where: { loginHandleNormalized: normalized },
+        select: { id: true },
+      })
+
+      if (holder && holder.id !== userId) {
+        throw new TRPCError({ code: 'CONFLICT', message: 'This login handle is already taken.' })
+      }
+
+      await ctx.prisma.user.update({
+        where: { id: userId },
+        data: {
+          loginHandle: normalized,
+          loginHandleNormalized: normalized,
+        },
+      })
+
+      return { success: true, loginHandle: normalized }
+    }),
+
+  setPassword: protectedProcedure
+    .input(
+      z.object({
+        currentPassword: z.string().min(1).optional(),
+        newPassword: z.string().min(8).max(128),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id
+      const credential = await ctx.prisma.userCredential.findUnique({
+        where: { userId },
+      })
+
+      if (credential?.lockedUntil && credential.lockedUntil > new Date()) {
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message: 'Account is temporarily locked. Please try again later.',
+        })
+      }
+
+      if (credential) {
+        if (!input.currentPassword) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Current password is required to change password.',
+          })
+        }
+
+        const verified = await verifyPassword(input.currentPassword, credential.passwordHash)
+        if (!verified) {
+          const failedAttempts = credential.failedAttempts + 1
+          await ctx.prisma.userCredential.update({
+            where: { userId },
+            data: {
+              failedAttempts,
+              lockedUntil:
+                failedAttempts >= PASSWORD_MAX_FAILED_ATTEMPTS
+                  ? new Date(Date.now() + PASSWORD_LOCK_MINUTES * 60 * 1000)
+                  : null,
+            },
+          })
+          throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Current password is incorrect.' })
+        }
+      }
+
+      const passwordHash = await hashPassword(input.newPassword)
+      await ctx.prisma.userCredential.upsert({
+        where: { userId },
+        update: {
+          passwordHash,
+          passwordUpdatedAt: new Date(),
+          failedAttempts: 0,
+          lockedUntil: null,
+        },
+        create: {
+          userId,
+          passwordHash,
+          passwordUpdatedAt: new Date(),
+        },
+      })
+
+      return { success: true }
+    }),
+})

--- a/server/api/routers/course.ts
+++ b/server/api/routers/course.ts
@@ -441,17 +441,11 @@ export const courseRouter = router({
       let hasFullAccess = false
       let userReviewCount = 0
 
-      if (ctx.session?.user?.email) {
-        const user = await ctx.prisma.user.findUnique({
-          where: { email: ctx.session.user.email },
-          select: { id: true },
+      if (ctx.session?.user?.id) {
+        userReviewCount = await ctx.prisma.review.count({
+          where: { authorId: ctx.session.user.id },
         })
-        if (user) {
-          userReviewCount = await ctx.prisma.review.count({
-            where: { authorId: user.id },
-          })
-          hasFullAccess = userReviewCount >= 1
-        }
+        hasFullAccess = userReviewCount >= 1
       }
 
       // Sort reviews: highest-voted first for the preview

--- a/server/api/trpc/context.ts
+++ b/server/api/trpc/context.ts
@@ -4,10 +4,17 @@ import { prisma } from '@/lib/prisma'
 
 export async function createTRPCContext(opts: FetchCreateContextFnOptions) {
   const session = await auth()
-  
+  const forwarded = opts.req.headers.get('x-forwarded-for')
+  const ip = forwarded?.split(',')[0]?.trim() || undefined
+  const userAgent = opts.req.headers.get('user-agent') || undefined
+
   return {
     session,
     prisma,
+    requestMeta: {
+      ip,
+      userAgent,
+    },
   }
 }
 

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -9,6 +9,9 @@ declare module 'next-auth' {
       image?: string | null
       nickname?: string | null
       role?: 'STUDENT' | 'MODERATOR' | 'ADMIN'
+      loginHandle?: string | null
+      eligibilityStatus?: 'UNVERIFIED' | 'STUDENT_VERIFIED' | 'ALUMNI_VERIFIED'
+      requiresRecoverySetup?: boolean
     }
   }
 }


### PR DESCRIPTION

- add identity models (UserEmail/UserCredential/EmailOtpChallenge) and migration
- implement auth tRPC router for signup OTP, recovery OTP, reset password, and security settings
- add credentials provider (handle/email + password) and Google account reconciliation
- update signin/signup/profile security UI for handle, password, and recovery email
- switch review authorization to eligibility status and refresh docs/env examples